### PR TITLE
Bugfixes - getFlags() and getVoltage()

### DIFF
--- a/bq34z100.cpp
+++ b/bq34z100.cpp
@@ -74,6 +74,7 @@ int bq34z100::readControl(uint8_t add,uint8_t add2)
     return temp;
 
 }
+
 //lets you read the instantainious current
 int bq34z100::readInstantCurrent()
 {
@@ -90,7 +91,7 @@ uint8_t bq34z100::getSOC()
     return Read(0x02, 2) ; //return temp in x10 format
 }
 
-int bq34z100::getVoltage()
+uint16_t bq34z100::getVoltage()
 {
     return Read(0x08, 2) ; //return temp in x10 format
 }
@@ -113,7 +114,19 @@ int bq34z100::getStatus()
 }
 int bq34z100::getFlags()
 {
-    return readControl(0x0E,0x0F);
+    Wire.beginTransmission(BQ34Z100);
+    Wire.write(0x0F);
+    Wire.write(0x0E);
+    Wire.write(0x0E);
+    Wire.endTransmission();
+
+    Wire.beginTransmission(BQ34Z100);
+    Wire.write(0x0E);
+    Wire.endTransmission();
+    Wire.requestFrom(BQ34Z100, 2);
+    int16_t temp = Wire.read();
+    temp = temp | (Wire.read() << 8);
+    return temp;
 }
 void bq34z100::reset()
 {

--- a/bq34z100.h
+++ b/bq34z100.h
@@ -15,7 +15,7 @@ public:
     bq34z100();
     uint8_t getSOC();//gets the current state of charge %
     int getTemp();//returns the temperature in C
-    int getVoltage();//returns the battery voltage
+    uint16_t getVoltage();//returns the battery voltage
     int getCapacity();//returns the current battery capacity
     int getCurrent();//returns the current flowing atm
     int getStatus();//returns the flags


### PR DESCRIPTION
Hello, I have made the following improvements:
1. Earlier, **getFlags and getStatus were returning the same value**. Now **this bug has been fixed** by changing the I2C address in getFlags function.
2.Earlier **getVoltages was returning 'signed int'** so voltages > 32V were not measurable, but as gauge supports voltage measurement up to 65V, this **data-type has been changed to 'unsigned int'.**

Hope that you will merge the PR.
Thank you for the awesome library! 